### PR TITLE
Inclusão de Escrevente de Gabinete - Função gratificada

### DIFF
--- a/remuneracao-tjsp/index.html
+++ b/remuneracao-tjsp/index.html
@@ -17,6 +17,7 @@
 				<label for="cargo">Cargo em comissão/Função gratificada</label>
 				<select id="cargo">
 					<option value="">Nenhum</option>
+					<option value="etjGab">Escrevente - Gabinete</option>
 					<option value="ajc">Assistente Judiciário</option>
 					<option value="csj">Chefe de Seção Judiciário</option>
 				</select>

--- a/remuneracao-tjsp/scripts/calculos.js
+++ b/remuneracao-tjsp/scripts/calculos.js
@@ -14,11 +14,13 @@ function calcSallary() {
 	// RESOLUÇÃO N° 923/2024
 	const multiplicadoresGaj = [
 		{ cargo: "", valor:  4.191 },
+		{ cargo: "etjGab", valor: 5.367 },
 		{ cargo: "ajc", valor: 6.187 },
 		{ cargo: "csj", valor: 5.948 }
 	];
 	const multiplicadoresRepr = [
 		{ cargo: "", valor: 0.0 },
+		{ cargo: "etjGab", valor: 0.434 },
 		{ cargo: "ajc", valor: 1.815 },
 		{ cargo: "csj", valor: 0.283 }
 	];


### PR DESCRIPTION
Inclusão da função gratificada de Escrevente de Gabinete, com GAJ de 536,70 e Grat. de Representação de 43,40.